### PR TITLE
Fixed post-processing module definition

### DIFF
--- a/SPUIS/runSpuis.py
+++ b/SPUIS/runSpuis.py
@@ -19,6 +19,7 @@ import shutil
 import time
 import matplotlib.pyplot as plt
 import subprocess
+import importlib.util
 
 #%% Set constants (Directory with code
 spuisdir = os.getcwd()+'/SPUIS/SPUIS401'
@@ -26,7 +27,10 @@ spuisEXE = 'SPUISV03.exe'
 
 #%% Functions
 sys.path.insert(1, spuisdir)
-import py.POSTPROC as pp
+module_path = os.path.join(spuisdir, 'py', 'POSTPROC.py')
+spec = importlib.util.spec_from_file_location('POSTPROC', module_path)
+pp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pp) # As an alternative to "import py.POSTPROC as pp"
 
 #%% Options
 print('')


### PR DESCRIPTION
Updated the way in which the post-processing module is created from POSTPROC.py to avoid confusion between "py." as the folder in which POSTPROC.py is located, and a library that would be called "py". 